### PR TITLE
Add support for client certificate based authentication

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,7 +194,15 @@
                             },
                             "ca": {
                                 "type": "string",
-                                "description": "Path for cert file or cert string in PEM format"
+                                "description": "Absolute path for cert file or cert string in PEM format"
+                            },
+                            "key": {
+                                "type": "string",
+                                "description": "Absolute path for client cert file or cert string in PEM format"
+                            },
+                            "cert": {
+                                "type": "string",
+                                "description": "Absolute path for client key file or cert string in PEM format"
                             },
                             "savedSubscriptions": {
                                 "type": "array",

--- a/src/MqttClientFactory.ts
+++ b/src/MqttClientFactory.ts
@@ -28,6 +28,30 @@ export class MqttClientFactory {
             }
         }
 
+        if (options.key) {
+            if (isAbsolutePath(options.key, "\\") || isAbsolutePath(options.key, "/")) {
+                try {
+                    options.key = fs.readFileSync(options.key);
+                } catch (error) {
+                    options.key = undefined;
+                    console.error(error);
+                    vscode.window.showErrorMessage("Could not open client key file");
+                }
+            }
+        }
+
+        if (options.cert) {
+            if (isAbsolutePath(options.cert, "\\") || isAbsolutePath(options.cert, "/")) {
+                try {
+                    options.cert = fs.readFileSync(options.cert);
+                } catch (error) {
+                    options.cert = undefined;
+                    console.error(error);
+                    vscode.window.showErrorMessage("Could not open client key file");
+                }
+            }
+        }
+
         client = connect(options);
         MqttClientFactory.clients.set(options.name, client);
         return client;

--- a/src/MqttConnectionView.ts
+++ b/src/MqttConnectionView.ts
@@ -157,8 +157,12 @@ export class MqttConnectionView {
     private _initMqtt() {
         this._mqttClient = MqttClientFactory.createClient(this.brokerConfig);
 
-        this._mqttClient.once('error', async () => {
-            const result = await vscode.window.showErrorMessage(`Could not connect to ${this.brokerConfig.host}`, "Open settings.json");
+        this._mqttClient.once('error', async (error : Error) => {
+            const result = await vscode.window.showErrorMessage(
+                `Could not connect to ${this.brokerConfig.host} - ${error.message}`, 
+                "Open settings.json"
+            );
+            
             if (result) {
                 await vscode.commands.executeCommand("workbench.action.openWorkspaceSettingsFile");
             }

--- a/src/interfaces/MqttBrokerConfig.ts
+++ b/src/interfaces/MqttBrokerConfig.ts
@@ -12,5 +12,10 @@ export interface MqttBrokerConfig {
     password?: string;
     ca?: Buffer|string;
     caString?: string;
+    key?: Buffer|string;
+    keytring?: string;
+    cert?: Buffer|string;
+    certString?: string;
+    passphrase?: string;
     savedSubscriptions?: Array<MqttSubscription>;
 }


### PR DESCRIPTION
fixes #163 

This adds the missing options to provide a client certificate and the client key to successfully authenticate with a MQTT endpoint using mqtts.